### PR TITLE
readme: fix syntax error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Loop:
 		case <-t.C:
 			fmt.Printf("  transferred %v / %v bytes (%.2f%%)\n",
 				resp.BytesComplete(),
-				resp.Size,
+				resp.Size(),
 				100*resp.Progress())
 
 		case <-resp.Done:


### PR DESCRIPTION
i saw that the resp.Size was a int64 val before, but it was a function now.